### PR TITLE
changed link to session

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 dependencies:
   kemal-session:
     github: kemalcr/kemal-session
-    version: 0.6.0
+    branch: master
 
 development_dependencies:
   kemal:


### PR DESCRIPTION
Tried changing to 0.7.0 first but this didn't work. I think it may be because the shard version was changed after the release. Master works though.