### PR TITLE
Change default error message

### DIFF
--- a/src/kemal-csrf.cr
+++ b/src/kemal-csrf.cr
@@ -11,7 +11,7 @@ require "kemal-session"
 # where an attacker can re-submit a form.
 #
 class CSRF < Kemal::Handler
-  def initialize(@header = "X_CSRF_TOKEN", @allowed_methods = %w(GET HEAD OPTIONS TRACE), @parameter_name = "authenticity_token", @error : String | (HTTP::Server::Context -> String) = "Forbidden", @allowed_routes = [] of String)
+  def initialize(@header = "X_CSRF_TOKEN", @allowed_methods = %w(GET HEAD OPTIONS TRACE), @parameter_name = "authenticity_token", @error : String | (HTTP::Server::Context -> String) = "Forbidden (CSRF)", @allowed_routes = [] of String)
     setup
   end
 


### PR DESCRIPTION
Took me way longer then I want to admit to figure out why I was getting a 403. I'd like to suggest changing the default error message to include it's related to CSRF.