### PR TITLE
Version updates to pass specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ require "kemal-csrf"
 add_handler CSRF.new
 ```
 
+To access the CSRF token of the active session you can do the following in your .ecr form(s)
+```html
+<input type="hidden" name="authenticity_token" value='<%= env.session.string("csrf") %>'>
+```
+
 You can also change the name of the form field, header name, the methods which don't need csrf,error message and routes which you don't want csrf to apply.
 All of these are optional
 ```crystal

--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,10 @@
 name: kemal-csrf
-version: 0.6.0
+version: 0.6.1
 
 dependencies:
   kemal-session:
     github: kemalcr/kemal-session
-    version: 0.12.0
+    version: ~> 0.12.0
 
 development_dependencies:
   kemal:


### PR DESCRIPTION
Specs are failing for this shard at the moment due to pointing to old kemal-session version 0.12.0, which doesn't work.

<img width="765" alt="Screenshot 2020-10-29 at 07 45 06" src="https://user-images.githubusercontent.com/35740142/97544585-bfab7700-19c1-11eb-9f2d-22428e954220.png">

So it needs to point to 0.12.1 instead.
I've updated shard.yml to point to new keml-session.

Specs now passing.

Also the README could have been clearer on how to use the token in the front end template. So I've included that as well.

Note that the kemal guide implies the token **name** should be **_csrf**, this just doesn't work as kemal-csrf seems to expect only the **authenticity_token** name.

So this appears misleading, if you could please update this as well :)

<img width="1084" alt="Screenshot 2020-10-29 at 08 38 14" src="https://user-images.githubusercontent.com/35740142/97545041-56783380-19c2-11eb-83fa-dc441645d0f0.png">

Thank you. Great work on Kemal. I'm new to Crystal and loving the idea behind it!