### PR TITLE
user can now set http_only and samesite

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ add_handler CSRF.new(
   allowed_methods: ["GET", "HEAD", "OPTIONS", "TRACE"],
   allowed_routes: ["/api/somecallback"],
   parameter_name: "_csrf", 
-  error: "CSRF Error" 
+  error: "CSRF Error",
+  http_only: false,
+  samesite: nil,
 )
 ```
 

--- a/src/kemal-csrf.cr
+++ b/src/kemal-csrf.cr
@@ -9,9 +9,15 @@ require "kemal-session"
 #
 # Without CSRF protection, your app is vulnerable to replay attacks
 # where an attacker can re-submit a form.
-#
 class CSRF < Kemal::Handler
-  def initialize(@header = "X_CSRF_TOKEN", @allowed_methods = %w(GET HEAD OPTIONS TRACE), @parameter_name = "authenticity_token", @error : String | (HTTP::Server::Context -> String) = "Forbidden (CSRF)", @allowed_routes = [] of String)
+  def initialize(
+    @header = "X_CSRF_TOKEN",
+    @allowed_methods = %w(GET HEAD OPTIONS TRACE),
+    @parameter_name = "authenticity_token",
+    @error : String | (HTTP::Server::Context -> String) = "Forbidden (CSRF)",
+    @allowed_routes = [] of String,
+    @http_only : Bool = false,
+    @samesite : HTTP::Cookie::SameSite? = nil)
     setup
   end
 
@@ -33,7 +39,8 @@ class CSRF < Kemal::Handler
         name: @parameter_name,
         value: csrf_token,
         expires: Time.local.to_utc + Kemal::Session.config.timeout,
-        http_only: false
+        http_only: @http_only,
+        samesite: @samesite,
       )
     end
 


### PR DESCRIPTION
This PR adds two additional parameters to the CSRF handler that makes it possible to set httpOnly and SameSite. This is something that was requested in #27 and #28 .

Should close #27, close #28 