### PR TITLE
Fix allowed routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        crystal: [latest, nightly]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install Crystal
+        uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+
+      - name: Download source
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: shards install
+        env:
+          SHARDS_OPTS: --ignore-crystal-version
+
+      - name: Run specs
+        run: |
+          crystal spec
+          crystal spec --release --no-debug

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ dependencies:
 development_dependencies:
   kemal:
     github: kemalcr/kemal
-    version: "~> 1.0.0"
+    version: "~> 1.3.0"
 
 authors:
   - Serdar Dogruyol <dogruyolserdar@gmail.com>

--- a/src/kemal-csrf.cr
+++ b/src/kemal-csrf.cr
@@ -19,7 +19,7 @@ class CSRF < Kemal::Handler
     @allowed_routes.each do |path|
       class_name = {{@type.name}}
       %w(GET HEAD OPTIONS TRACE PUT POST).each do |method|
-        @@exclude_routes_tree.add "#{class_name}/#{method.downcase}#{path}", "/#{method.downcase}#{path}"
+        @@exclude_routes_tree.add "#{class_name}/#{method}#{path}", "/#{method}#{path}"
       end
     end
   end


### PR DESCRIPTION
I found that `allowed_routes` param wasn't working on my app and saw that Kemal `exclude` macro [doesn't downcase the method name](https://github.com/kemalcr/kemal/blob/8ebe171279a8fff80dd4b207541062731a5eda13/src/kemal/handler.cr#L24) (perhaps this changed at some point after `1.0.0` release). This was causing `allowed_routes` not to match as expected. There's also an incompatibility issue that shipped in kemal `1.3.0` release to support Crystal `1.6.0` so that specs can run which requires the dependency bump.